### PR TITLE
REMOVE typecasting of WP_Admin_Bar in TablePress_Admin_Controller::add_wp_admin_bar_new_content_menu_entry()

### DIFF
--- a/controllers/controller-admin.php
+++ b/controllers/controller-admin.php
@@ -269,9 +269,9 @@ class TablePress_Admin_Controller extends TablePress_Controller {
 	 *
 	 * @since 1.0.0
 	 *
-	 * @param WP_Admin_Bar $wp_admin_bar The current WP Admin Bar object.
+	 * @param class $wp_admin_bar The current WP Admin Bar object.
 	 */
-	public function add_wp_admin_bar_new_content_menu_entry( WP_Admin_Bar $wp_admin_bar ) {
+	public function add_wp_admin_bar_new_content_menu_entry( $wp_admin_bar ) {
 		if ( ! current_user_can( 'tablepress_add_tables' ) ) {
 			return;
 		}


### PR DESCRIPTION
It is possible to completely override the WP_Admin_Bar class using the 'wp_admin_bar_class' filter in wp-includes/admin-bar.php

So, typecasting this method's argument as such can cause a Fatal error should that class not be instantiated.

This pull request prevents that from happening.
