### PR TITLE
add support for UTF-16 import

### DIFF
--- a/controllers/controller-admin.php
+++ b/controllers/controller-admin.php
@@ -1332,6 +1332,10 @@ class TablePress_Admin_Controller extends TablePress_Controller {
 			if ( ! isset( $import_data['data'] ) ) {
 				$import_data['data'] = file_get_contents( $import_data['file_location'] );
 			}
+			/* supports UTF-16 import */
+			if( substr( $import_data['data'], 0, 2 ) == "\xFF\xFE" ) {
+				    $import_data['data'] = iconv( 'UTF-16', 'UTF-8', $import_data['data'] );
+			}
 			if ( false === $import_data['data'] ) {
 				TablePress::redirect( array( 'action' => 'import', 'message' => 'error_import' ) );
 			}


### PR DESCRIPTION
some .csv files like, Google Developers Console Stats, are delivered in UTF-16.