### PR TITLE
Add translation to Post Type registered name

### DIFF
--- a/models/model-post.php
+++ b/models/model-post.php
@@ -54,7 +54,7 @@ class TablePress_Post_Model extends TablePress_Model {
 		$this->post_type = apply_filters( 'tablepress_post_type', $this->post_type );
 		$post_type_args = array(
 			'labels' => array(
-				'name' => __('TablePress Tables', 'tablepress' ),
+				'name' => _x('TablePress Tables', 'post type general name', 'tablepress' ),
 			),
 			'public' => false,
 			'show_ui' => false,

--- a/models/model-post.php
+++ b/models/model-post.php
@@ -54,7 +54,7 @@ class TablePress_Post_Model extends TablePress_Model {
 		$this->post_type = apply_filters( 'tablepress_post_type', $this->post_type );
 		$post_type_args = array(
 			'labels' => array(
-				'name' => 'TablePress Tables',
+				'name' => __('TablePress Tables', 'tablepress' ),
 			),
 			'public' => false,
 			'show_ui' => false,


### PR DESCRIPTION
I'm pulling this as a suggestion that needs to be checked, I've seen it working in other plugins but I'm not sure why isn't working here.
It's the one that still appears untranslated in my list of registered post types.

I've made it according to this:
https://codex.wordpress.org/Function_Reference/register_post_type

Feel free to reject this if you don't find this usefull.