### PR TITLE
Add hook for TablePress_All_Tables_List_Table

### DIFF
--- a/views/view-list.php
+++ b/views/view-list.php
@@ -511,6 +511,21 @@ class TablePress_All_Tables_List_Table extends WP_List_Table {
 	}
 
 	/**
+	 *
+	 * @param object $item
+	 * @param string $column_name
+	 */
+	function column_default( $item, $column_name ){
+		/**
+		 * Fires inside each custom column of the TablePress list table.
+		 *
+		 * @param string $item object of a row
+		 * @param array  $column_name Name of the column.
+		 */
+		do_action( "manage_tablepress_list_custom_column", $item, $column_name );
+	}
+	
+	/**
 	 * Get a list (name => title) bulk actions that are available.
 	 *
 	 * @since 1.0.0


### PR DESCRIPTION
Hello,

For add a column to your WP_List_Table in screen : `wp-admin/index.php?page=tablepress`, we can use hook in standard developpement. But in the class `wp-admin/includes/class-wp-list-table.php` It just have this hook :

* `manage_{$this->screen->id}_columns` for declare a column and set a title
*  `manage_{$this->screen->id}_sortable_columns` for sorting

But nothing for add information in a row.

In documentation : https://make.wordpress.org/docs/plugin-developer-handbook/10-plugin-components/custom-list-table-columns/#output-table-cell-contents
The hook `manage_{$screen->id}_custom_column` exist but not in the code of the class WP_List_Table.

The child should create this hook.

Thanks