### PR TITLE
switched quotes with double-quotes.

### DIFF
--- a/controllers/controller-frontend.php
+++ b/controllers/controller-frontend.php
@@ -292,7 +292,7 @@ class TablePress_Frontend_Controller extends TablePress_Controller {
 					$parameters['orderClasses'] = '"orderClasses":false';
 				}
 				// Alternating row colors is default, so remove them if not wanted with [].
-				$parameters['stripeClasses'] = '"stripeClasses":' . ( ( $js_options['alternating_row_colors'] ) ? "['even','odd']" : '[]' );
+				$parameters['stripeClasses'] = '"stripeClasses":' . ( ( $js_options['alternating_row_colors'] ) ? '["even","odd"]' : '[]' );
 				// The following options are activated by default, so we only need to "false" them if we don't want them, but don't need to "true" them if we do.
 				if ( ! $js_options['datatables_sort'] ) {
 					$parameters['ordering'] = '"ordering":false';


### PR DESCRIPTION
very minor issue. 

however, using double-quotes around strings would make the parameters object compliant with the [JSON specification](https://tools.ietf.org/html/rfc7159#section-7) (at least in the default configuration).

so, why would i need this?

I'm in the process of writing a TablePress extension and need to open-up/augment `$parameters` in my `tablepress_datatables_command` callback function. 
I'm using `json_decode()`, which currently fails due to the single quotes around `odd` and `even`.

anyhow, this would help me a great deal, i hope you can fold this change into your code-base.

thanks!