### PR TITLE
Always Use Uploads Directory to Store Cache Files

### DIFF
--- a/classes/class-css.php
+++ b/classes/class-css.php
@@ -121,16 +121,7 @@ class TablePress_CSS {
 				break;
 		}
 
-		if ( is_multisite() ) {
-			// Multisite installation: /wp-content/uploads/sites/<ID>/
-			$upload_location = wp_upload_dir();
-		} else {
-			// Singlesite installation: /wp-content/
-			$upload_location = array(
-				'basedir' => WP_CONTENT_DIR,
-				'baseurl' => content_url(),
-			);
-		}
+		$upload_location = wp_upload_dir();
 
 		switch ( $location ) {
 			case 'url':


### PR DESCRIPTION
## what
* write cache file to wordpress uploads directory for multi-site and single-site installations

## why
* wp-content root is for code, not for dynamically generated files.
* multi-server setups typically will share uploads directory over NFS, but not code
* for consistency, files should be written to the same location regardless of whether or not multi-site being used. 
* wp-content should not be writable by the web server for security purposes, but `uploads/` generally is writable to support uploads.