### PR TITLE
Accessibility improvements for view-edit

### DIFF
--- a/admin/css/edit.css
+++ b/admin/css/edit.css
@@ -233,3 +233,8 @@ body #wp-link-backdrop {
 #tablepress_edit-table-manipulation .column-2 {
 	width: 55%;
 }
+
+/* Align with checkbox labels */
+.checkbox-left {
+	padding-left: 24px; /* Checkboxes are 16px wide + 4px margin, with 4px :before */
+}

--- a/views/view-edit.php
+++ b/views/view-edit.php
@@ -211,7 +211,7 @@ class TablePress_Edit_View extends TablePress_View {
 <table class="tablepress-postbox-table fixed">
 <tbody>
 	<tr class="bottom-border">
-		<th class="column-1" scope="row"><label for="table-id"><?php _e( 'Table ID', 'tablepress' ); ?>:</label></th>
+		<th class="column-1" scope="row"><label for="table-new-id"><?php _e( 'Table ID', 'tablepress' ); ?>:</label></th>
 		<td class="column-2">
 			<input type="hidden" name="table[id]" id="table-id" value="<?php echo esc_attr( $data['table']['id'] ); ?>" />
 			<input type="text" name="table[new_id]" id="table-new-id" value="<?php echo esc_attr( $data['table']['id'] ); ?>" title="<?php esc_attr_e( 'The Table ID can only consist of letters, numbers, hyphens (-), and underscores (_).', 'tablepress' ); ?>" pattern="[A-Za-z0-9-_]+" required <?php echo ( ! current_user_can( 'tablepress_edit_table_id', $data['table']['id'] ) ) ? 'readonly ' : ''; ?>/>

--- a/views/view-edit.php
+++ b/views/view-edit.php
@@ -677,7 +677,8 @@ class TablePress_Edit_View extends TablePress_View {
 		<?php _e( 'For example, you can insert things like text, images, or links into the table, or change the used table features. You can also insert, delete, move, hide, and swap columns and rows.', 'tablepress' ); ?>
 	</p>
 	<p>
-		<?php printf( __( 'To insert the table into a page, post, or text widget, copy the Shortcode %s and paste it at the desired place in the editor.', 'tablepress' ), '<input type="text" class="table-shortcode table-shortcode-inline" value="' . esc_attr( '[' . TablePress::$shortcode . " id={$data['table']['id']} /]" ) . '" readonly="readonly" />' ); ?>
+		<label class="screen-reader-only" for="table-shortcode-inline"><?php esc_html_e( 'Shortcode text for editor', 'tablepress' ); ?></label>
+		<?php printf( __( 'To insert the table into a page, post, or text widget, copy the Shortcode %s and paste it at the desired place in the editor.', 'tablepress' ), '<input type="text" id="table-shortcode-inline" class="table-shortcode table-shortcode-inline" value="' . esc_attr( '[' . TablePress::$shortcode . " id={$data['table']['id']} /]" ) . '" readonly="readonly" />' ); ?>
 	</p>
 		<?php
 	}

--- a/views/view-edit.php
+++ b/views/view-edit.php
@@ -274,8 +274,8 @@ class TablePress_Edit_View extends TablePress_View {
 <table id="edit-form" class="tablepress-edit-screen-id-<?php echo esc_attr( $data['table']['id'] ); ?>">
 	<thead>
 		<tr id="edit-form-head">
-			<th><span class="screen-reader-text"><?php esc_html_e( 'Row Index', 'tablepress' ); ?></th>
-			<th><span class="screen-reader-text"><?php esc_html_e( 'Bulk action selectors for rows', 'tablepress' ); ?></span></th>
+			<th scope="col"><span class="screen-reader-text"><?php esc_html_e( 'Row Index', 'tablepress' ); ?></th>
+			<th scope="col"><span class="screen-reader-text"><?php esc_html_e( 'Bulk action selectors for rows', 'tablepress' ); ?></span></th>
 <?php
 	for ( $col_idx = 0; $col_idx < $columns; $col_idx++ ) {
 		$column_class = '';
@@ -283,10 +283,10 @@ class TablePress_Edit_View extends TablePress_View {
 			$column_class = ' column-hidden';
 		}
 		$column = TablePress::number_to_letter( $col_idx + 1 );
-		echo "\t\t\t<th class=\"head{$column_class}\"><span class=\"sort-control sort-desc hide-if-no-js\" title=\"" . esc_attr__( 'Sort descending', 'tablepress' ) . '"><span class="sorting-indicator"></span></span><span class="sort-control sort-asc hide-if-no-js" title="' . esc_attr__( 'Sort ascending', 'tablepress' ) . "\"><span class=\"sorting-indicator\"></span></span><span class=\"move-handle\">{$column}</span></th>\n";
+		echo "\t\t\t<th scope=\"col\" class=\"head{$column_class}\"><span class=\"sort-control sort-desc hide-if-no-js\" title=\"" . esc_attr__( 'Sort descending', 'tablepress' ) . '"><span class="sorting-indicator"></span></span><span class="sort-control sort-asc hide-if-no-js" title="' . esc_attr__( 'Sort ascending', 'tablepress' ) . "\"><span class=\"sorting-indicator\"></span></span><span class=\"move-handle\">{$column}</span></th>\n";
 	}
 ?>
-			<th><span class="screen-reader-text"><?php esc_html_e( 'Row Index', 'tablepress' ); ?></th>
+			<th scope="col"><span class="screen-reader-text"><?php esc_html_e( 'Row Index', 'tablepress' ); ?></th>
 		</tr>
 	</thead>
 	<tbody id="edit-form-body">
@@ -328,8 +328,8 @@ class TablePress_Edit_View extends TablePress_View {
 	</tbody>
 	<tfoot>
 		<tr id="edit-form-foot">
-			<th><span class="screen-reader-text"><?php esc_html_e( 'Row Index', 'tablepress' ); ?></th>
-			<th><span class="screen-reader-text"><?php esc_html_e( 'Bulk action selectors for rows', 'tablepress' ); ?></span></th>
+			<th scope="col"><span class="screen-reader-text"><?php esc_html_e( 'Row Index', 'tablepress' ); ?></th>
+			<th scope="col"><span class="screen-reader-text"><?php esc_html_e( 'Bulk action selectors for rows', 'tablepress' ); ?></span></th>
 <?php
 	for ( $col_idx = 0; $col_idx < $columns; $col_idx++ ) {
 		$column_class = '';
@@ -337,11 +337,11 @@ class TablePress_Edit_View extends TablePress_View {
 			$column_class = ' class="column-hidden"';
 		}
 		$column_selector_text = esc_attr( sprintf( __( 'Bulk action selector for column %s', 'tablepress' ), TablePress::number_to_letter( $col_idx + 1 ) ) );
-		echo "\t\t\t<th{$column_class}><label class=\"hide-if-no-js\"><span class=\"screen-reader-text\">{$column_selector_text}</span><input type=\"checkbox\" /></label>";
+		echo "\t\t\t<th scope=\"col\" {$column_class}><label class=\"hide-if-no-js\"><span class=\"screen-reader-text\">{$column_selector_text}</span><input type=\"checkbox\" /></label>";
 		echo "<input type=\"hidden\" class=\"visibility\" name=\"table[visibility][columns][]\" value=\"{$visibility['columns'][ $col_idx ]}\" /></th>\n";
 	}
 ?>
-			<th><span class="screen-reader-text"><?php esc_html_e( 'Row Index', 'tablepress' ); ?></th>
+			<th scope="col"><span class="screen-reader-text"><?php esc_html_e( 'Row Index', 'tablepress' ); ?></th>
 		</tr>
 	</tfoot>
 </table>

--- a/views/view-edit.php
+++ b/views/view-edit.php
@@ -318,7 +318,8 @@ class TablePress_Edit_View extends TablePress_View {
 			}
 			// Sanitize, so that HTML is possible in table cells.
 			$cell = esc_textarea( $cell );
-			echo "<td{$column_class}><textarea name=\"table[data][{$row_idx}][{$col_idx}]\" id=\"cell-{$column}{$row}\" rows=\"1\">{$cell}</textarea></td>";
+			$cell_label = esc_attr( sprintf( __( 'Column %s Row %s', 'tablepress' ), number_format_i18n( $column ), number_format_i18n( $row ) ) );
+			echo "<td{$column_class}><label><span class=\"screen-reader-text\">{$cell_label}</span><textarea name=\"table[data][{$row_idx}][{$col_idx}]\" id=\"cell-{$column}{$row}\" title=\"{$cell_title}\" rows=\"1\">{$cell}</textarea></label></td>";
 		}
 		echo "<td><span class=\"move-handle\">{$row}</span></td>\n";
 		echo "\t\t</tr>\n";

--- a/views/view-edit.php
+++ b/views/view-edit.php
@@ -274,7 +274,7 @@ class TablePress_Edit_View extends TablePress_View {
 <table id="edit-form" class="tablepress-edit-screen-id-<?php echo esc_attr( $data['table']['id'] ); ?>">
 	<thead>
 		<tr id="edit-form-head">
-			<th scope="col"><span class="screen-reader-text"><?php esc_html_e( 'Row Index', 'tablepress' ); ?></span></th>
+			<th scope="col"><span class="screen-reader-text"><?php esc_html_e( 'Row Number', 'tablepress' ); ?></span></th>
 			<th scope="col"><span class="screen-reader-text"><?php esc_html_e( 'Bulk action selectors for rows', 'tablepress' ); ?></span></th>
 <?php
 	for ( $col_idx = 0; $col_idx < $columns; $col_idx++ ) {
@@ -286,7 +286,7 @@ class TablePress_Edit_View extends TablePress_View {
 		echo "\t\t\t<th scope=\"col\" class=\"head{$column_class}\"><span class=\"sort-control sort-desc hide-if-no-js\" title=\"" . esc_attr__( 'Sort descending', 'tablepress' ) . '"><span class="sorting-indicator"></span></span><span class="sort-control sort-asc hide-if-no-js" title="' . esc_attr__( 'Sort ascending', 'tablepress' ) . "\"><span class=\"sorting-indicator\"></span></span><span class=\"move-handle\">{$column}</span></th>\n";
 	}
 ?>
-			<th scope="col"><span class="screen-reader-text"><?php esc_html_e( 'Row Index', 'tablepress' ); ?></span></th>
+			<th scope="col"><span class="screen-reader-text"><?php esc_html_e( 'Row Number', 'tablepress' ); ?></span></th>
 		</tr>
 	</thead>
 	<tbody id="edit-form-body">
@@ -328,7 +328,7 @@ class TablePress_Edit_View extends TablePress_View {
 	</tbody>
 	<tfoot>
 		<tr id="edit-form-foot">
-			<th scope="col"><span class="screen-reader-text"><?php esc_html_e( 'Row Index', 'tablepress' ); ?></span></th>
+			<th scope="col"><span class="screen-reader-text"><?php esc_html_e( 'Row Number', 'tablepress' ); ?></span></th>
 			<th scope="col"><span class="screen-reader-text"><?php esc_html_e( 'Bulk action selectors for rows', 'tablepress' ); ?></span></th>
 <?php
 	for ( $col_idx = 0; $col_idx < $columns; $col_idx++ ) {
@@ -341,7 +341,7 @@ class TablePress_Edit_View extends TablePress_View {
 		echo "<input type=\"hidden\" class=\"visibility\" name=\"table[visibility][columns][]\" value=\"{$visibility['columns'][ $col_idx ]}\" /></th>\n";
 	}
 ?>
-			<th scope="col"><span class="screen-reader-text"><?php esc_html_e( 'Row Index', 'tablepress' ); ?></span></th>
+			<th scope="col"><span class="screen-reader-text"><?php esc_html_e( 'Row Number', 'tablepress' ); ?></span></th>
 		</tr>
 	</tfoot>
 </table>

--- a/views/view-edit.php
+++ b/views/view-edit.php
@@ -411,10 +411,10 @@ class TablePress_Edit_View extends TablePress_View {
 	</tr>
 	<tr class="top-border">
 		<td class="column-1">
-			<?php printf( __( 'Add %s row(s)', 'tablepress' ), '<input type="number" id="rows-append-number" class="small-text numbers-only" title="' . esc_attr__( 'This field must contain a positive number.', 'tablepress' ) . '" value="1" min="1" max="99999" maxlength="5" required />' ); ?>&nbsp;<input type="button" class="button" id="rows-append" value="<?php esc_attr_e( 'Add', 'tablepress' ); ?>" />
+			<label><?php printf( __( 'Add %s row(s)', 'tablepress' ), '<input type="number" id="rows-append-number" class="small-text numbers-only" title="' . esc_attr__( 'This field must contain a positive number.', 'tablepress' ) . '" value="1" min="1" max="99999" maxlength="5" required />' ); ?></label>&nbsp;<input type="button" class="button" id="rows-append" value="<?php esc_attr_e( 'Add', 'tablepress' ); ?>" />
 		</td>
 		<td class="column-2">
-			<?php printf( __( 'Add %s column(s)', 'tablepress' ), '<input type="number" id="columns-append-number" class="small-text numbers-only" title="' . esc_attr__( 'This field must contain a positive number.', 'tablepress' ) . '" value="1" min="1" max="99999" maxlength="5" required />' ); ?>&nbsp;<input type="button" class="button" id="columns-append" value="<?php esc_attr_e( 'Add', 'tablepress' ); ?>" />
+			<label><?php printf( __( 'Add %s column(s)', 'tablepress' ), '<input type="number" id="columns-append-number" class="small-text numbers-only" title="' . esc_attr__( 'This field must contain a positive number.', 'tablepress' ) . '" value="1" min="1" max="99999" maxlength="5" required />' ); ?></label>&nbsp;<input type="button" class="button" id="columns-append" value="<?php esc_attr_e( 'Add', 'tablepress' ); ?>" />
 		</td>
 	</tr>
 </table>
@@ -539,24 +539,25 @@ class TablePress_Edit_View extends TablePress_View {
 		<td class="column-2"><label for="option-row-hover"><input type="checkbox" id="option-row-hover" name="table[options][row_hover]" value="true"<?php checked( $options['row_hover'] ); ?> /> <?php _e( 'Highlight a row while the mouse cursor hovers above it by changing its background color.', 'tablepress' ); ?></label></td>
 	</tr>
 	<tr class="top-border">
-		<th class="column-1" scope="row"><?php _e( 'Print Table Name', 'tablepress' ); ?>:</th>
+		<th class="column-1" scope="row"><label for="option-print-name"><?php _e( 'Print Table Name', 'tablepress' ); ?></label>:</th>
 		<?php
 			$position_select = '<select id="option-print-name-position" name="table[options][print_name_position]">';
 			$position_select .= '<option' . selected( 'above', $options['print_name_position'], false ) . ' value="above">' . __( 'above', 'tablepress' ) . '</option>';
 			$position_select .= '<option' . selected( 'below', $options['print_name_position'], false ) . ' value="below">' . __( 'below', 'tablepress' ) . '</option>';
 			$position_select .= '</select>';
 		?>
-		<td class="column-2"><input type="checkbox" id="option-print-name" name="table[options][print_name]" value="true"<?php checked( $options['print_name'] ); ?> /> <?php printf( __( 'Show the table name %s the table.', 'tablepress' ), $position_select ); ?></td>
+		<td class="column-2"><input type="checkbox" id="option-print-name" name="table[options][print_name]" value="true"<?php checked( $options['print_name'] ); ?> /> <label><?php printf( __( 'Show the table name %s the table.', 'tablepress' ), $position_select ); ?></label></td>
 	</tr>
 	<tr class="bottom-border">
-		<th class="column-1" scope="row"><?php _e( 'Print Table Description', 'tablepress' ); ?>:</th>
+		<th class="column-1" scope="row"><label for="option-print-description"><?php _e( 'Print Table Description', 'tablepress' ); ?></label>:</th>
 		<?php
-			$position_select = '<select id="option-print-description-position" name="table[options][print_description_position]">';
+			$position_select  = '</label><label for="option-print-description-position">';
+			$position_select .= '<select id="option-print-description-position" name="table[options][print_description_position]">';
 			$position_select .= '<option' . selected( 'above', $options['print_description_position'], false ) . ' value="above">' . __( 'above', 'tablepress' ) . '</option>';
 			$position_select .= '<option' . selected( 'below', $options['print_description_position'], false ) . ' value="below">' . __( 'below', 'tablepress' ) . '</option>';
 			$position_select .= '</select>';
 		?>
-		<td class="column-2"><input type="checkbox" id="option-print-description" name="table[options][print_description]" value="true"<?php checked( $options['print_description'] ); ?> /> <?php printf( __( 'Show the table description %s the table.', 'tablepress' ), $position_select ); ?></td>
+		<td class="column-2"><input type="checkbox" id="option-print-description" name="table[options][print_description]" value="true"<?php checked( $options['print_description'] ); ?> /> <label><?php printf( __( 'Show the table description %s the table.', 'tablepress' ), $position_select ); ?></label></td>
 	</tr>
 	<tr class="top-border">
 		<th class="column-1" scope="row"><?php _e( 'Extra CSS Classes', 'tablepress' ); ?>:</th>
@@ -596,7 +597,7 @@ class TablePress_Edit_View extends TablePress_View {
 	<tr>
 		<th class="column-1" scope="row" style="vertical-align: top;"><?php _e( 'Pagination', 'tablepress' ); ?>:</th>
 		<td class="column-2"><label for="option-datatables-paginate"><input type="checkbox" id="option-datatables-paginate" name="table[options][datatables_paginate]" value="true"<?php checked( $options['datatables_paginate'] ); ?> /> <?php _e( 'Enable pagination of the table (viewing only a certain number of rows at a time) by the visitor.', 'tablepress' ); ?></label><br />
-		<label for="option-datatables-paginate_entries"><input type="checkbox" style="visibility: hidden;" <?php // Dummy checkbox for space alignment ?>/> <?php printf( __( 'Show %s rows per page.', 'tablepress' ), '<input type="number" id="option-datatables-paginate_entries" name="table[options][datatables_paginate_entries]" value="' . intval( $options['datatables_paginate_entries'] ) . '" min="1" max="99999" maxlength="5" required />' ); ?></label></td>
+		<label for="option-datatables-paginate_entries" class="checkbox-left"><?php printf( __( 'Show %s rows per page.', 'tablepress' ), '<input type="number" id="option-datatables-paginate_entries" name="table[options][datatables_paginate_entries]" value="' . intval( $options['datatables_paginate_entries'] ) . '" min="1" max="99999" maxlength="5" required />' ); ?></label></td>
 	</tr>
 	<tr>
 		<th class="column-1" scope="row"><?php _e( 'Pagination Length Change', 'tablepress' ); ?>:</th>

--- a/views/view-edit.php
+++ b/views/view-edit.php
@@ -490,6 +490,7 @@ class TablePress_Edit_View extends TablePress_View {
 ?>
 <div class="hidden-container">
 	<div id="advanced-editor">
+		<label for="advanced-editor-content" class="screen-reader-text"><?php esc_html_e( 'Advanced Editor', 'tablepress' ); ?></label>
 	<?php
 		$wp_editor_options = array(
 			'textarea_rows' => 10,

--- a/views/view-edit.php
+++ b/views/view-edit.php
@@ -309,7 +309,7 @@ class TablePress_Edit_View extends TablePress_View {
 		$row_selector_text = esc_attr( sprintf( __( 'Bulk action selector for row %s', 'tablepress' ), number_format_i18n( $row ) ) );
 		echo "\t\t<tr{$row_class}>\n";
 		echo "\t\t\t<td><span class=\"move-handle\">{$row}</span></td>";
-		echo "<td><label class=\"hide-if-no-js\"><span class=\"screen-reader-text\">{$row_selector_text}</span><input type=\"checkbox\" /><input type=\"hidden\" class=\"visibility\" name=\"table[visibility][rows][]\" value=\"{$visibility['rows'][ $row_idx ]}\" /></td>";
+		echo "<td><label class=\"hide-if-no-js\"><span class=\"screen-reader-text\">{$row_selector_text}</span><input type=\"checkbox\" /><input type=\"hidden\" class=\"visibility\" name=\"table[visibility][rows][]\" value=\"{$visibility['rows'][ $row_idx ]}\" /></label></td>";
 		foreach ( $row_data as $col_idx => $cell ) {
 			$column = TablePress::number_to_letter( $col_idx + 1 );
 			$column_class = '';

--- a/views/view-edit.php
+++ b/views/view-edit.php
@@ -274,7 +274,7 @@ class TablePress_Edit_View extends TablePress_View {
 <table id="edit-form" class="tablepress-edit-screen-id-<?php echo esc_attr( $data['table']['id'] ); ?>">
 	<thead>
 		<tr id="edit-form-head">
-			<th scope="col"><span class="screen-reader-text"><?php esc_html_e( 'Row Index', 'tablepress' ); ?></th>
+			<th scope="col"><span class="screen-reader-text"><?php esc_html_e( 'Row Index', 'tablepress' ); ?></span></th>
 			<th scope="col"><span class="screen-reader-text"><?php esc_html_e( 'Bulk action selectors for rows', 'tablepress' ); ?></span></th>
 <?php
 	for ( $col_idx = 0; $col_idx < $columns; $col_idx++ ) {
@@ -286,7 +286,7 @@ class TablePress_Edit_View extends TablePress_View {
 		echo "\t\t\t<th scope=\"col\" class=\"head{$column_class}\"><span class=\"sort-control sort-desc hide-if-no-js\" title=\"" . esc_attr__( 'Sort descending', 'tablepress' ) . '"><span class="sorting-indicator"></span></span><span class="sort-control sort-asc hide-if-no-js" title="' . esc_attr__( 'Sort ascending', 'tablepress' ) . "\"><span class=\"sorting-indicator\"></span></span><span class=\"move-handle\">{$column}</span></th>\n";
 	}
 ?>
-			<th scope="col"><span class="screen-reader-text"><?php esc_html_e( 'Row Index', 'tablepress' ); ?></th>
+			<th scope="col"><span class="screen-reader-text"><?php esc_html_e( 'Row Index', 'tablepress' ); ?></span></th>
 		</tr>
 	</thead>
 	<tbody id="edit-form-body">
@@ -309,7 +309,7 @@ class TablePress_Edit_View extends TablePress_View {
 		$row_selector_text = esc_attr( sprintf( __( 'Bulk action selector for row %s', 'tablepress' ), number_format_i18n( $row ) ) );
 		echo "\t\t<tr{$row_class}>\n";
 		echo "\t\t\t<td><span class=\"move-handle\">{$row}</span></td>";
-		echo "<td><label class=\"hide-if-no-js\"><span class=\"screen-reader-text\">{$row_selector_text}</span><input type=\"checkbox\" /><input type=\"hidden\" class=\"visibility\" name=\"table[visibility][rows][]\" value=\"{$visibility['rows'][ $row_idx ]}\" /></span></td>";
+		echo "<td><label class=\"hide-if-no-js\"><span class=\"screen-reader-text\">{$row_selector_text}</span><input type=\"checkbox\" /><input type=\"hidden\" class=\"visibility\" name=\"table[visibility][rows][]\" value=\"{$visibility['rows'][ $row_idx ]}\" /></td>";
 		foreach ( $row_data as $col_idx => $cell ) {
 			$column = TablePress::number_to_letter( $col_idx + 1 );
 			$column_class = '';
@@ -328,7 +328,7 @@ class TablePress_Edit_View extends TablePress_View {
 	</tbody>
 	<tfoot>
 		<tr id="edit-form-foot">
-			<th scope="col"><span class="screen-reader-text"><?php esc_html_e( 'Row Index', 'tablepress' ); ?></th>
+			<th scope="col"><span class="screen-reader-text"><?php esc_html_e( 'Row Index', 'tablepress' ); ?></span></th>
 			<th scope="col"><span class="screen-reader-text"><?php esc_html_e( 'Bulk action selectors for rows', 'tablepress' ); ?></span></th>
 <?php
 	for ( $col_idx = 0; $col_idx < $columns; $col_idx++ ) {
@@ -341,7 +341,7 @@ class TablePress_Edit_View extends TablePress_View {
 		echo "<input type=\"hidden\" class=\"visibility\" name=\"table[visibility][columns][]\" value=\"{$visibility['columns'][ $col_idx ]}\" /></th>\n";
 	}
 ?>
-			<th scope="col"><span class="screen-reader-text"><?php esc_html_e( 'Row Index', 'tablepress' ); ?></th>
+			<th scope="col"><span class="screen-reader-text"><?php esc_html_e( 'Row Index', 'tablepress' ); ?></span></th>
 		</tr>
 	</tfoot>
 </table>

--- a/views/view-edit.php
+++ b/views/view-edit.php
@@ -274,8 +274,8 @@ class TablePress_Edit_View extends TablePress_View {
 <table id="edit-form" class="tablepress-edit-screen-id-<?php echo esc_attr( $data['table']['id'] ); ?>">
 	<thead>
 		<tr id="edit-form-head">
-			<th></th>
-			<th></th>
+			<th><span class="screen-reader-text"><?php esc_html_e( 'Row Index', 'tablepress' ); ?></th>
+			<th><span class="screen-reader-text"><?php esc_html_e( 'Bulk action selectors for rows', 'tablepress' ); ?></span></th>
 <?php
 	for ( $col_idx = 0; $col_idx < $columns; $col_idx++ ) {
 		$column_class = '';
@@ -286,7 +286,7 @@ class TablePress_Edit_View extends TablePress_View {
 		echo "\t\t\t<th class=\"head{$column_class}\"><span class=\"sort-control sort-desc hide-if-no-js\" title=\"" . esc_attr__( 'Sort descending', 'tablepress' ) . '"><span class="sorting-indicator"></span></span><span class="sort-control sort-asc hide-if-no-js" title="' . esc_attr__( 'Sort ascending', 'tablepress' ) . "\"><span class=\"sorting-indicator\"></span></span><span class=\"move-handle\">{$column}</span></th>\n";
 	}
 ?>
-			<th></th>
+			<th><span class="screen-reader-text"><?php esc_html_e( 'Row Index', 'tablepress' ); ?></th>
 		</tr>
 	</thead>
 	<tbody id="edit-form-body">
@@ -326,8 +326,8 @@ class TablePress_Edit_View extends TablePress_View {
 	</tbody>
 	<tfoot>
 		<tr id="edit-form-foot">
-			<th></th>
-			<th></th>
+			<th><span class="screen-reader-text"><?php esc_html_e( 'Row Index', 'tablepress' ); ?></th>
+			<th><span class="screen-reader-text"><?php esc_html_e( 'Bulk action selectors for rows', 'tablepress' ); ?></span></th>
 <?php
 	for ( $col_idx = 0; $col_idx < $columns; $col_idx++ ) {
 		$column_class = '';
@@ -338,7 +338,7 @@ class TablePress_Edit_View extends TablePress_View {
 		echo "<input type=\"hidden\" class=\"visibility\" name=\"table[visibility][columns][]\" value=\"{$visibility['columns'][ $col_idx ]}\" /></th>\n";
 	}
 ?>
-			<th></th>
+			<th><span class="screen-reader-text"><?php esc_html_e( 'Row Index', 'tablepress' ); ?></th>
 		</tr>
 	</tfoot>
 </table>

--- a/views/view-edit.php
+++ b/views/view-edit.php
@@ -306,9 +306,10 @@ class TablePress_Edit_View extends TablePress_View {
 			$classes[] = 'row-hidden';
 		}
 		$row_class = ( ! empty( $classes ) ) ? ' class="' . implode( ' ', $classes ) . '"' : '';
+		$row_selector_text = esc_attr( sprintf( __( 'Bulk action selector for row %s', 'tablepress' ), number_format_i18n( $row ) ) );
 		echo "\t\t<tr{$row_class}>\n";
 		echo "\t\t\t<td><span class=\"move-handle\">{$row}</span></td>";
-		echo "<td><input type=\"checkbox\" class=\"hide-if-no-js\" /><input type=\"hidden\" class=\"visibility\" name=\"table[visibility][rows][]\" value=\"{$visibility['rows'][ $row_idx ]}\" /></td>";
+		echo "<td><label class=\"hide-if-no-js\"><span class=\"screen-reader-text\">{$row_selector_text}</span><input type=\"checkbox\" /><input type=\"hidden\" class=\"visibility\" name=\"table[visibility][rows][]\" value=\"{$visibility['rows'][ $row_idx ]}\" /></span></td>";
 		foreach ( $row_data as $col_idx => $cell ) {
 			$column = TablePress::number_to_letter( $col_idx + 1 );
 			$column_class = '';
@@ -334,7 +335,8 @@ class TablePress_Edit_View extends TablePress_View {
 		if ( 0 === $visibility['columns'][ $col_idx ] ) {
 			$column_class = ' class="column-hidden"';
 		}
-		echo "\t\t\t<th{$column_class}><input type=\"checkbox\" class=\"hide-if-no-js\" />";
+		$column_selector_text = esc_attr( sprintf( __( 'Bulk action selector for column %s', 'tablepress' ), TablePress::number_to_letter( $col_idx + 1 ) ) );
+		echo "\t\t\t<th{$column_class}><label class=\"hide-if-no-js\"><span class=\"screen-reader-text\">{$column_selector_text}</span><input type=\"checkbox\" /></label>";
 		echo "<input type=\"hidden\" class=\"visibility\" name=\"table[visibility][columns][]\" value=\"{$visibility['columns'][ $col_idx ]}\" /></th>\n";
 	}
 ?>

--- a/views/view-edit.php
+++ b/views/view-edit.php
@@ -555,7 +555,7 @@ class TablePress_Edit_View extends TablePress_View {
 	<tr class="bottom-border">
 		<th class="column-1" scope="row"><label for="option-print-description"><?php _e( 'Print Table Description', 'tablepress' ); ?></label>:</th>
 		<?php
-			$position_select  = '<select id="option-print-description-position" name="table[options][print_description_position]">';
+			$position_select = '<select id="option-print-description-position" name="table[options][print_description_position]">';
 			$position_select .= '<option' . selected( 'above', $options['print_description_position'], false ) . ' value="above">' . __( 'above', 'tablepress' ) . '</option>';
 			$position_select .= '<option' . selected( 'below', $options['print_description_position'], false ) . ' value="below">' . __( 'below', 'tablepress' ) . '</option>';
 			$position_select .= '</select>';

--- a/views/view-edit.php
+++ b/views/view-edit.php
@@ -555,8 +555,7 @@ class TablePress_Edit_View extends TablePress_View {
 	<tr class="bottom-border">
 		<th class="column-1" scope="row"><label for="option-print-description"><?php _e( 'Print Table Description', 'tablepress' ); ?></label>:</th>
 		<?php
-			$position_select  = '</label><label for="option-print-description-position">';
-			$position_select .= '<select id="option-print-description-position" name="table[options][print_description_position]">';
+			$position_select  = '<select id="option-print-description-position" name="table[options][print_description_position]">';
 			$position_select .= '<option' . selected( 'above', $options['print_description_position'], false ) . ' value="above">' . __( 'above', 'tablepress' ) . '</option>';
 			$position_select .= '<option' . selected( 'below', $options['print_description_position'], false ) . ' value="below">' . __( 'below', 'tablepress' ) . '</option>';
 			$position_select .= '</select>';


### PR DESCRIPTION
Hi @TobiasBg - Thanks for the great plugin!

I'm doing an accessibilty review for a client, and I've started with some improvements to view-edit.php.

The commit messages have most of the technical details, but here's a summary:
- Ensured that all input elements have labels. Sometimes this meant `screen-reader-text` labels, sometimes it meant using a technique like the one at https://core.trac.wordpress.org/browser/tags/4.9.3/src/wp-admin/options-discussion.php#L107 to label multiple form fields with a single sentence.
- Ensured that `th` elements had (screen-reader-only) text and `scope`
- Removed the "hidden checkbox" alignment trick, which is clever but not screen-reader friendly :)

Happy to discuss or modify any of these suggestions, or break them out into smaller PRs. (I'll likely be sending PRs, and thought it would be helpful to group by functionality.) Thanks!