### PR TITLE
Fix Travis CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,25 @@ before_script:
   - phpenv versions
   - php --version
   - php -m
+  - |
+    # Install the specified version of PHPUnit depending on the PHP version:
+    if [[ 1 == 1 ]]; then
+      case "$TRAVIS_PHP_VERSION" in
+        7.2|7.1|7.0|nightly)
+          echo "Using PHPUnit 6.x"
+          composer global require "phpunit/phpunit:^6"
+          ;;
+        5.6)
+          echo "Using PHPUnit 4.x"
+          composer global require "phpunit/phpunit:^4"
+          ;;
+        *)
+          echo "No PHPUnit version handling for PHP version $TRAVIS_PHP_VERSION"
+          exit 1
+          ;;
+      esac
+    fi
+  - export PATH="$HOME/.composer/vendor/bin:$PATH"
   - which phpunit
   - phpunit --version
   - git --version

--- a/tablepress.php
+++ b/tablepress.php
@@ -41,9 +41,17 @@ Donate URI: https://tablepress.org/donate/
 defined( 'ABSPATH' ) || die( 'No direct script access allowed!' );
 
 // Define certain plugin variables as constants.
-define( 'TABLEPRESS_ABSPATH', plugin_dir_path( __FILE__ ) );
-define( 'TABLEPRESS__FILE__', __FILE__ );
-define( 'TABLEPRESS_BASENAME', plugin_basename( TABLEPRESS__FILE__ ) );
+if ( ! defined( 'TABLEPRESS_ABSPATH' ) ) {
+	define( 'TABLEPRESS_ABSPATH', plugin_dir_path( __FILE__ ) );
+}
+
+if ( ! defined( 'TABLEPRESS__FILE__' ) ) {
+	define( 'TABLEPRESS__FILE__', __FILE__ );
+}
+
+if ( ! defined( 'TABLEPRESS_BASENAME' ) ) {
+	define( 'TABLEPRESS_BASENAME', plugin_basename( TABLEPRESS__FILE__ ) );
+}
 
 /**
  * Load TablePress class, which holds common functions and variables.

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -7,20 +7,29 @@
  * @since 1.1.0
  */
 
-// Activates TablePress in WordPress so it can be tested.
-$GLOBALS['wp_tests_options'] = array(
-	'active_plugins' => array( 'tablepress/tablepress.php' ),
-);
-
 /*
  * If the WP unit tests location is defined (as WP_TESTS_DIR), use that location.
  * Otherwise, we assume that this plugin is installed in a WordPress Develop repository checkout.
  */
 if ( false !== getenv( 'WP_TESTS_DIR' ) ) {
-	require getenv( 'WP_TESTS_DIR' ) . 'includes/bootstrap.php';
+	$wp_tests_dir = getenv( 'WP_TESTS_DIR' );
 } else {
-	require '../../../../../tests/phpunit/includes/bootstrap.php';
+	$wp_tests_dir = '../../../../../tests/phpunit';
 }
+
+$GLOBALS['wp_tests_options'] = array(
+	'active_plugins' => array( 'tablepress/tablepress.php' ),
+);
+
+require_once $wp_tests_dir . 'includes/functions.php';
+
+// Activates TablePress in WordPress so it can be tested.
+function tablepress_tests_init() {
+	require dirname( dirname( __FILE__) ) . '/tablepress.php';
+}
+tests_add_filter( 'plugins_loaded', 'tablepress_tests_init' );
+
+require $wp_tests_dir . 'includes/bootstrap.php';
 
 /**
  * TablePress Unit Testing Testcase class.


### PR DESCRIPTION
I didn't like seeing the red X, so I did some work to fix the Travis CI build.

This required both some Travis-specific changes (such as loading a custom version of `phpunit` depending on the PHP version) as well as some changes to the PHPUnit bootstrap to get the suite to run locally.