### PR TITLE
Don't show "Custom CSS was not saved to file" error if the feature ha…

### DIFF
--- a/classes/class-css.php
+++ b/classes/class-css.php
@@ -227,7 +227,7 @@ class TablePress_CSS {
 		 * @param bool $save Whether to save the "Custom CSS" to a file. Default true.
 		 */
 		if ( ! apply_filters( 'tablepress_save_custom_css_to_file', true ) ) {
-			return false;
+			return true;
 		}
 
 		// Start capturing the output, to later prevent it.


### PR DESCRIPTION
…s been disabled.

If you've disabled the saving of custom CSS to a file using a filter:

    add_filter( 'tablepress_save_custom_css_to_file', '__return_false' );

then it's not really an "error" condition if the plugin fails to save to file, and it can be somewhat confusing for users who get a "...could not save to file" notice. This PR is my suggested fix: as before, bail out of `save_custom_css_to_file()` when the feature is turned off, but return `true` instead of `false` so you don't get the error message.