### PR TITLE
Specify path to phpunit executable.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,11 +39,11 @@ before_script:
       case "$TRAVIS_PHP_VERSION" in
         7.3|7.2|7.1|7.0|nightly)
           echo "Using PHPUnit 6.x for PHP version $TRAVIS_PHP_VERSION"
-          composer global require "phpunit/phpunit:^6"
+          composer require "phpunit/phpunit:^6"
           ;;
         5.6)
           echo "Using PHPUnit 4.x for PHP version $TRAVIS_PHP_VERSION"
-          composer global require "phpunit/phpunit:^4"
+          composer require "phpunit/phpunit:^4"
           ;;
         *)
           echo "No PHPUnit version handling for PHP version $TRAVIS_PHP_VERSION"
@@ -52,8 +52,6 @@ before_script:
       esac
     fi
   - export PATH="$HOME/.composer/vendor/bin:$PATH"
-  - which phpunit
-  - phpunit --version
   - git --version
   - locale -a
   - export WP_DEVELOP_DIR=/tmp/wordpress

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -2,8 +2,8 @@
 
 # Run single-site unit tests:
 export WP_MULTISITE=0
-phpunit --exclude-group=ms-required
+./vendor/bin/phpunit --exclude-group=ms-required
 
 # Run Multisite unit tests:
 export WP_MULTISITE=1
-phpunit --exclude-group=ms-excluded
+./vendor/bin/phpunit --exclude-group=ms-excluded


### PR DESCRIPTION
See #89.

@TobiasBg This is the only way I can reliably get Travis to use the correct `phpunit` executable. (The problem with the previous technique was that `phpunit` was still calling the system executable, even though `.composer` was in the `$PATH`.) Not sure if it's the "right" way, but it works.