### PR TITLE
Should Exit Early

### DIFF
--- a/classes/class-tablepress.php
+++ b/classes/class-tablepress.php
@@ -106,11 +106,24 @@ abstract class TablePress {
 		 */
 		do_action( 'tablepress_run' );
 
+
+        // Default logic to exit early if TablePress doesn't have to be loaded.
+        $should_exit = ( 'wp-login.php' === basename( $_SERVER['SCRIPT_FILENAME'] ) ) // Login screen
+                       || ( defined( 'XMLRPC_REQUEST' ) && XMLRPC_REQUEST )
+                       || ( defined( 'DOING_CRON' ) && DOING_CRON );
+
+        /**
+         * Allow TablePress to load if required
+         *
+         * @since 1.14.1
+         *
+         * @param bool $should_exit Should TablePress Exit Early if it does not have to be loaded
+         */
+        $should_exit = apply_filters( 'tablepress_disable_exit', true );
+
 		// Exit early if TablePress doesn't have to be loaded.
-		if ( ( 'wp-login.php' === basename( $_SERVER['SCRIPT_FILENAME'] ) ) // Login screen
-			|| ( defined( 'XMLRPC_REQUEST' ) && XMLRPC_REQUEST )
-			|| ( defined( 'DOING_CRON' ) && DOING_CRON ) ) {
-			return;
+		if ( $should_exit ) {
+            return;
 		}
 
 		// Check if minimum requirements are fulfilled, currently WordPress 5.6.

--- a/controllers/controller-frontend.php
+++ b/controllers/controller-frontend.php
@@ -409,7 +409,7 @@ JS;
 		/**
 		 * Filter the script/jQuery wrapper code for the DataTables commands calls.
 		 *
-		 * @since 1.14.0
+		 * @since 1.14.1
 		 *
 		 * @param string $js_wrapper Default script/jQuery wrapper code for the DataTables commands calls.
 		 */

--- a/tablepress.php
+++ b/tablepress.php
@@ -4,13 +4,13 @@
  *
  * @package TablePress
  * @author Tobias Bäthge
- * @version 1.14
+ * @version 1.14.1
  *
  *
  * Plugin Name: TablePress
  * Plugin URI: https://tablepress.org/
  * Description: Embed beautiful and feature-rich tables into your posts and pages, without having to write code.
- * Version: 1.14
+ * Version: 1.14.1
  * Requires at least: 5.6
  * Requires PHP: 5.6.20
  * Author: Tobias Bäthge


### PR DESCRIPTION
Minor feature to allow plugin to be enabled via a filter if being run via CRON or something that would typically cause TablePress to exit early.