### PR TITLE
Update excel-reader.class.php

### DIFF
--- a/libraries/excel-reader.class.php
+++ b/libraries/excel-reader.class.php
@@ -1067,7 +1067,7 @@ class Spreadsheet_Excel_Reader {
 	 * @param [type] $prop  [description]
 	 * @return [type] [description]
 	 */
-	public function fontProperty( $row, $col, $sheet = 0, $prop ) {
+	public function fontProperty( $row, $col, $sheet = 0, $prop = null ) {
 		$font = $this->fontRecord( $row, $col, $sheet );
 		if ( null !== $font ) {
 			return $font[ $prop ];


### PR DESCRIPTION
Deprecated in PHP 8.0: Required parameter $prop follows optional parameter $sheet.