### PR TITLE
Add WordPress VIP staging URLs to local address logic

### DIFF
--- a/libraries/freemius/includes/entities/class-fs-site.php
+++ b/libraries/freemius/includes/entities/class-fs-site.php
@@ -204,7 +204,10 @@
 				// InstaWP
 				fs_ends_with( $subdomain, '.instawp.xyz' ) ||
 				// 10Web Hosting
-				( fs_ends_with( $subdomain, '-dev.10web.site' ) || fs_ends_with( $subdomain, '-dev.10web.cloud' ) )
+				( fs_ends_with( $subdomain, '-dev.10web.site' ) || fs_ends_with( $subdomain, '-dev.10web.cloud' ) ) ||
+				// WordPress VIP staging/preprod environments
+				( fs_ends_with( $subdomain, '-develop.go-vip.net' ) || fs_ends_with( $subdomain, '-preprod.go-vip.net' ) )
+				
 			);
 		}
 


### PR DESCRIPTION
PR adds the staging URLs added for WordPress VIP customers for develop and preprod environments.

https://docs.wpvip.com/domains/convenience-domains/